### PR TITLE
Correctly setting env parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.orig
 *.swp
+/salt/top.sls

--- a/salt/lax/config/srv-lax-app.cfg
+++ b/salt/lax/config/srv-lax-app.cfg
@@ -1,6 +1,6 @@
 [general]
 debug: False
-env: prod
+env: {{ pillar.elife.env }}
 secret-key: {{ pillar.lax.app.secret }}
 # ll: ".example.org"
 # matches anything coming from "example.org"
@@ -12,7 +12,7 @@ inception: 2012-11-13
 
 [bus]
 name: {{ pillar.lax.sns.name }}
-env: prod
+env: {{ pillar.elife.env }}
 region: {{ pillar.lax.sns.region }}
 subscriber: {{ pillar.lax.sns.subscriber }}
 


### PR DESCRIPTION
Taking a look at the code, the first one is used only to compare it with
`dev` so inserting the environment names here won't make a difference.

The second one is used to compose the name of the topic, so it should
definitely vary depending on the environment
