### PR TITLE
Configuring bot-lax-adaptor under Upstart

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -10,3 +10,5 @@ base:
         # LSH 2016-06-22: disabled until elife-reporting fully resolved
         #- elife-reporting
         - lax.adaptors
+        # disabled on local VMs
+        #- lax.processes

--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -17,6 +17,7 @@ bot-lax-adaptor:
     git.latest:
         - user: {{ pillar.elife.deploy_user.username }}
         - name: https://github.com/elifesciences/bot-lax-adaptor
+        - rev: master
         - target: /opt/bot-lax-adaptor/
         - force_fetch: True
         - force_checkout: True
@@ -30,3 +31,23 @@ bot-lax-adaptor:
         - require:
             - git: bot-lax-adaptor
             - pkg: bot-lax-adaptor
+
+bot-lax-adaptor-service:
+    file.managed:
+        - name: /etc/init/bot-lax-adaptor.conf
+        - source: salt://lax/config/etc-init-bot-lax-adaptor.conf
+        - template: jinja
+        - require:
+            - bot-lax-adaptor
+
+{% set number = 1 %}
+bot-lax-adaptors-task:
+    file.managed:
+        - name: /etc/init/bot-lax-adaptors.conf
+        - source: salt://elife/config/etc-init-multiple-processes.conf
+        - template: jinja
+        - context:
+            process: bot-lax-adaptor
+            number: {{ number }}
+        - require:
+            - bot-lax-adaptor-service

--- a/salt/lax/config/etc-init-bot-lax-adaptor.conf
+++ b/salt/lax/config/etc-init-bot-lax-adaptor.conf
@@ -1,0 +1,9 @@
+description "bot-lax-adaptor - pass an ID to distinguish between them"
+respawn
+kill timeout 30 # blocking for 20 seconds on polling, plus a few seconds for a new ingest
+setuid {{ pillar.elife.deploy_user.username }}
+instance $ID
+chdir /opt/bot-lax-adaptor
+script
+    exec ./bot-lax-listener.sh {{ pillar.elife.env }} $ID
+end script

--- a/salt/lax/config/home-deploy-user-.aws-credentials
+++ b/salt/lax/config/home-deploy-user-.aws-credentials
@@ -1,0 +1,4 @@
+aws_access_key_id = {{ pillar.lax.aws.access_key_id }}
+aws_secret_access_key = {{ pillar.lax.aws.secret_access_key }}
+region = {{ pillar.lax.aws.region }}
+

--- a/salt/lax/init.sls
+++ b/salt/lax/init.sls
@@ -123,3 +123,10 @@ configure-lax:
             - file: lax-ingest-log-file
             - postgres_database: lax-db-exists
 
+aws-credentials:
+    file.managed:
+        - user: /home/{{ pillar.elife.deploy_user.username }}/.aws/credentials
+        - source: lax/config/home-deploy-user-.aws-credentials
+        - template: jinja
+        - require:
+            - install-lax

--- a/salt/lax/processes.sls
+++ b/salt/lax/processes.sls
@@ -1,0 +1,5 @@
+bot-lax-adaptors-start:
+    cmd.run:
+        - name: start bot-lax-adaptors
+        - require:
+            - bot-lax-adaptors-task

--- a/salt/pillar/lax.sls
+++ b/salt/pillar/lax.sls
@@ -8,8 +8,12 @@ lax:
         password: barpass
         host: 127.0.0.1
         port: 5432
-
-    sns:
-        name: bus-articles
+    aws:
+        access_key_id: null
+        secret_access_key: null
         region: us-east-1
         subscriber: null
+    sns:
+        name: bus-articles
+        subscriber: null # TODO: remove in favor of pillar.lax.aws
+        region: us-east-1 # TODO: remove in favor of pillar.lax.aws

--- a/salt/pillar/lax.sls
+++ b/salt/pillar/lax.sls
@@ -8,3 +8,8 @@ lax:
         password: barpass
         host: 127.0.0.1
         port: 5432
+
+    sns:
+        name: bus-articles
+        region: us-east-1
+        subscriber: null


### PR DESCRIPTION
`bot-lax-adaptor-service` is an Upstart template to run a single bot-lax-adaptor script as a long-running process.
`bot-lax-adaptors-task` is our standard script for gracefully starting and stopping N instances of a service, in this case `bot-lax-adaptor-service`. N is 1 at the moment, no need for multiple processes but if they are needed in the future they are well supported.