### PR TITLE
Allow POSTs on /api/v2

### DIFF
--- a/salt/lax/config/etc-nginx-sitesavailable-lax.conf
+++ b/salt/lax/config/etc-nginx-sitesavailable-lax.conf
@@ -53,7 +53,7 @@ server {
     }
 
     # all api requests    
-    location /api/ {
+    location /api/v1/ {
         # API POST/PUT/UPDATE/whatever are restricted
         limit_except GET HEAD {
             auth_basic "restricted";


### PR DESCRIPTION
The previous Nginx configuration restricted /api to GET and HEAD. `/api/v2` manages authentication on its own and supports POSTs, so limiting this to `/api/v1`.