### PR TITLE
Lax authentication in nginx

### DIFF
--- a/salt/lax/config/etc-nginx-sitesavailable-lax.conf
+++ b/salt/lax/config/etc-nginx-sitesavailable-lax.conf
@@ -14,6 +14,7 @@ server {
 }
 {% endif %}
 
+variables_hash_max_size 2048; # to fit this map
 map $http_authorization $consumer_groups_filtered {
     default    "";
     {% for i, user in pillar.lax.app.users.items() %}
@@ -59,7 +60,7 @@ server {
         # WARNING: this value *must* be higher than uwsgi's 'harakiri' value
         # (10s) in /srv/lax/uwsgi.ini
         uwsgi_read_timeout 15s;
-        uwsgi_param X_CONSUMER_GROUPS $consumer_groups_filtered;
+        uwsgi_param HTTP_X_CONSUMER_GROUPS $consumer_groups_filtered;
         include /etc/uwsgi/params;
     }
 

--- a/salt/lax/config/etc-nginx-sitesavailable-lax.conf
+++ b/salt/lax/config/etc-nginx-sitesavailable-lax.conf
@@ -14,6 +14,13 @@ server {
 }
 {% endif %}
 
+map $http_authorization $consumer_groups_filtered {
+    default    "";
+    {% for i, user in pillar.lax.app.users.items() %}
+    "Basic {{ salt['hashutil.base64_b64encode'](user['username'] ~ ':' ~ user['password']) }}" $http_x_consumer_groups;
+    {% endfor %}
+}
+
 # configuration of the server
 server {
     # we always listen on port 80.
@@ -37,6 +44,9 @@ server {
     # max upload size
     client_max_body_size 5M;
 
+    # authentication debugging
+    add_header "X-Consumer-Groups-Filtered" $consumer_groups_filtered;
+
     # used for Swagger and admin
     location /static {
         alias /srv/lax/collected-static;
@@ -49,6 +59,7 @@ server {
         # WARNING: this value *must* be higher than uwsgi's 'harakiri' value
         # (10s) in /srv/lax/uwsgi.ini
         uwsgi_read_timeout 15s;
+        uwsgi_param X_CONSUMER_GROUPS $consumer_groups_filtered;
         include /etc/uwsgi/params;
     }
 

--- a/salt/pillar/lax.sls
+++ b/salt/pillar/lax.sls
@@ -4,6 +4,10 @@ lax:
         secret: dummy-secret-do-not-use-in-prod
         allow_invalid_ajson: False
         reporting_bucket: null
+        users:
+            api_gateway:
+                username: api-gateway
+                password: foo
     botlax:
         api_whitelist:
             - '127.0.0.1' # internal


### PR DESCRIPTION
This method replaces the need to check the ip address of the caller.

Nginx strips the X-Consumer-Groups header, letting it through only if the caller satisfied the basic authentication. Only the api-gateway should know this secret.

This can be deployed without any blocker as api-gateway already passes the Authorization header. After that, Lax can remove checks for REMOTE_ADDR.