### PR TITLE
Permissions for bot-lax-adaptor logs

### DIFF
--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -112,6 +112,11 @@ dir-{{ path }}:
             - move-requests-cache-file
         - require_in:
             - cmd: bot-lax-writable-dirs
+
+    cmd.run:
+        - name: chmod -R g+s {{ path }}
+        - require:
+            - file: var-directory
 {% endfor %}
 
 # added 2017-08-01 - temporary state, remove in due course

--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -116,7 +116,7 @@ dir-{{ path }}:
     cmd.run:
         - name: chmod -R g+s {{ path }}
         - require:
-            - file: var-directory
+            - file: dir-{{ path }}
 {% endfor %}
 
 # added 2017-08-01 - temporary state, remove in due course


### PR DESCRIPTION
Permissions for existing files are correct, but new files should inherit the www-data group.

Needs https://github.com/elifesciences/bot-lax-adaptor/pull/317