### PR TITLE
Rebuild venv from scratch in ci

### DIFF
--- a/salt/lax/init.sls
+++ b/salt/lax/init.sls
@@ -131,6 +131,9 @@ configure-lax:
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/lax/
         - name: |
+            {% if pillar.env in ['dev', 'ci'] %}
+            rm -rf venv
+            {% endif %}
             ./install.sh 
             ./download-api-raml.sh
             ./manage.sh collectstatic --noinput


### PR DESCRIPTION
Also reproduces a failure on recreating the virtualenv (we have a fix [for that](https://github.com/elifesciences/lax/pull/295)).