### PR TITLE
Patch connexion to 1.2

### DIFF
--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -37,6 +37,14 @@ bot-lax-adaptor:
             - file: bot-lax-adaptor
             - git: bot-lax-adaptor
 
+# the stable version of bot-lax-adaptor pins a version of connextion
+# that has stopped working
+bot-lax-adaptor-patch-connexion:
+    cmd.run:
+        - name: sed -i -e 's/^.*connexion.git.*$/connexion==1.2/g' /opt/bot-lax-adaptor/requirements.txt
+        - require:
+            - bot-lax-adaptor
+
 bot-lax-adaptor-config:
     file.managed:
         - user: {{ pillar.elife.deploy_user.username }}
@@ -54,6 +62,7 @@ bot-lax-adaptor-install:
         - require:
             - bot-lax-adaptor
             - bot-lax-adaptor-config
+            - bot-lax-adaptor-patch-connexion
 
 bot-lax-adaptor-service:
     file.managed:


### PR DESCRIPTION
The current version of bot-lax-adaptor does not build anymore and newer versions had some problems to be solved due to ELPP-3312. Hence let's patch the current version for a stable production and end2end, otherwise virtualenvs of bot-lax-adaptor cannot be created

Allows a green highstate on Vagrant.