### PR TITLE
sets graphql.enabled to True for the ci environment but otherwise False

### DIFF
--- a/salt/lax/config/srv-lax-app.cfg
+++ b/salt/lax/config/srv-lax-app.cfg
@@ -36,4 +36,4 @@ host: {{ salt['elife.cfg']('cfn.outputs.RDSHost') or pillar.elife.postgresql.hos
 port: {{ salt['elife.cfg']('cfn.outputs.RDSPort') or pillar.elife.postgresql.port }}
 
 [graphql]
-enabled: {% if pillar.elife.env in ['ci'] %}True{% else %}False{% endif %}
+enabled: {% if pillar.elife.env in ['continuumtest'] %}True{% else %}False{% endif %}

--- a/salt/lax/config/srv-lax-app.cfg
+++ b/salt/lax/config/srv-lax-app.cfg
@@ -34,3 +34,6 @@ user: {{ pillar.elife.db.app.username }}
 password: {{ pillar.elife.db.app.password }}
 host: {{ salt['elife.cfg']('cfn.outputs.RDSHost') or pillar.elife.postgresql.host }}
 port: {{ salt['elife.cfg']('cfn.outputs.RDSPort') or pillar.elife.postgresql.port }}
+
+[graphql]
+enabled: {% if pillar.elife.env in ['ci'] %}True{% else %}False{% endif %}


### PR DESCRIPTION
graphql support is an experimental feature that hasn't been merged into lax `master` yet.

this change is backwards compatible