### PR TITLE
[PI-626] Always restart uwsgi-bot-lax-adaptor

### DIFF
--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -171,18 +171,17 @@ uwsgi-bot-lax-adaptor:
 
     service.running:
         - enable: True
-        - reload: True
         - require:
             - file: uwsgi-params
             - file: uwsgi-bot-lax-adaptor
             - file: bot-lax-uwsgi-conf
             - file: bot-lax-nginx-conf
             - bot-lax-writable-dirs
-        - onchanges:
-            - bot-lax-adaptor
-        - watch:
-            # restart uwsgi if nginx service changes
-            - service: nginx-server-service
+
+    cmd.run:
+        - name: restart uwsgi-bot-lax-adaptor
+        - require:
+            - service: uwsgi-bot-lax-adaptor
 
     # test to ensure service is not serving up 500 responses
     # the 'listen' statement ensures it runs at the end of a state run


### PR DESCRIPTION
After finding 28-days-old code running in production in https://elifesciences.atlassian.net/browse/PI-626

This solution is a bit blunt but workarounds `service.running` lack of restarts (reload doesn't do anything for this daemon)