### PR TITLE
ELPP-3675 Use iiif.elifesciences.org as CDN hostname

### DIFF
--- a/salt/lax/config/opt-bot-lax-adaptor-app.cfg
+++ b/salt/lax/config/opt-bot-lax-adaptor-app.cfg
@@ -13,7 +13,11 @@ env_for_cdn: {{ pillar.elife.env }}
 {%- endif %}
 
 {% set scheme = 'http' if pillar.elife.env == 'dev' else 'https' %}
+{% if pillar.elife.env == 'prod' -%}
+cdn_iiif: {{ scheme }}://iiif.elifesciences.org/lax:
+{%- else -%}
 cdn_iiif: {{ scheme }}://{{ pillar.elife.env }}--cdn-iiif.elifesciences.org/lax:
+{%- endif %}
 iiif: {{ scheme }}://{{ pillar.elife.env }}--iiif.elifesciences.org/lax:
 
 [lax]


### PR DESCRIPTION
The iiif--prod CDN has a friendly name iiif.elifesciences.org (which is also the only one allowed to open its robots.txt to the world, see https://github.com/elifesciences/iiif-formula/pull/9 for details). We should use it when generating article JSON.