### PR TITLE
uwsgi-bot-lax smoke test

### DIFF
--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -192,4 +192,6 @@ uwsgi-bot-lax-smoke-test:
         - status: 200
         - wait_for: 10 # seconds. five checks with 1 second between each
         - request_interval: 1 # second
+        - require:
+            - uwsgi-bot-lax-adaptor
 

--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -186,15 +186,10 @@ uwsgi-bot-lax-adaptor:
         - require:
             - service: uwsgi-bot-lax-adaptor
 
-    # test to ensure service is not serving up 500 responses
-    # the 'listen' statement ensures it runs at the end of a state run
-    # currently doesn't work: due to `listen` it runs 
-    # after the listener_nginx-server-service restart
-    # but it also runs immediately here, and since nginx is not restarted yet, it fails because no one is answering on port 8001 yet
-    #cmd.run:
-    #    - name: |
-    #        curl --silent --include --head --fail {{ apiprotocol }}://{{ apihost }}:8001/ui/
-    #    - listen:
-    #        - service: nginx
-    #        - service: uwsgi-bot-lax-adaptor
+uwsgi-bot-lax-smoke-test:
+    http.wait_for_successful_query:
+        - name: {{ apiprotocol }}://{{ apihost }}:8001/ui/
+        - status: 200
+        - wait_for: 10 # seconds. five checks with 1 second between each
+        - request_interval: 1 # second
 

--- a/salt/lax/config/etc-logrotate.d-bot-lax-adaptor
+++ b/salt/lax/config/etc-logrotate.d-bot-lax-adaptor
@@ -1,4 +1,6 @@
 /var/log/bot-lax-adaptor/*.log {
+    # user:group, same as directory permissions
+    su {{ pillar.elife.deploy_user.username }} {{ pillar.elife.webserver.username }}
     daily
     rotate 7
     notifempty


### PR DESCRIPTION
* replaced disabled uwsgi-bot-lax (api) smoke test (current problem would have been detected if this had been working)
* fixes logrotate permissions for bot-lax