### PR TITLE
Correctly restart uwsgi process for lax and bot-lax-adaptor

### DIFF
--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -162,7 +162,7 @@ bot-lax-uwsgi-systemd:
 uwsgi-bot-lax-adaptor:
     service.running:
         - enable: True
-        # doesn't seem to be understood by uwsgi, so we restart manually with a cmd.run state
+        # doesn't seem to be understood by uwsgi, leave the default behavior of restarting rather than reloading, only changes
         # - reload: True
         - require:
             - file: bot-lax-uwsgi-upstart
@@ -171,18 +171,9 @@ uwsgi-bot-lax-adaptor:
             - file: bot-lax-nginx-conf
             - bot-lax-writable-dirs
 
-        - onchanges:
-            - bot-lax-adaptor
         - watch:
-            # restart uwsgi if nginx service changes
-            - service: nginx-server-service
-
-    # disabled 2018-09-097 in preference for 'onchanges' and 'watch' above
-    #cmd.run:
-    #    # we need to restart to load new Python code just deployed
-    #    - name: restart uwsgi-bot-lax-adaptor
-    #    - require:
-    #        - service: uwsgi-bot-lax-adaptor
+            # will always trigger a restart since it's a `cmd` state
+            - cmd: bot-lax-adaptor
 
 # disabled. because of `listen` requisites in builder-base.nginx, I can't get this
 # state to reliably run after the service is running without the service then

--- a/salt/lax/uwsgi.sls
+++ b/salt/lax/uwsgi.sls
@@ -41,6 +41,4 @@ uwsgi-lax:
             - file: lax-nginx-conf
             - file: lax-log-file
         - watch:
-            - install-lax
-            # restart uwsgi if nginx service changes
-            - service: nginx-server-service
+            - file: install-lax


### PR DESCRIPTION
From https://github.com/elifesciences/issues/issues/4484

- remove `onchanges`: would only execute `service.running` in case of changes, hence not starting a dead service; will never restart the service even with changes
- restarts the service using [`service.mod_watch`](https://docs.saltstack.com/en/2017.7/ref/states/all/salt.states.service.html#salt.states.service.mod_watch) which is triggered by the `watch` requisite
- makes the watch for `uwsgi-bot-lax-adaptor` a `cmd`, meaning it always has changes and cause the restart
- makes the watch for `uwsgi-lax` the `file.directory`, meaning it always has changes and cause the restart. This is the existing behavior.

Have tested various combinations on 14.04, will check the build outputs of 16.04.