### PR TITLE
points sqlite to /ext/tmp for VACUUM operation

### DIFF
--- a/salt/lax/bot-lax-adaptor.sls
+++ b/salt/lax/bot-lax-adaptor.sls
@@ -191,7 +191,9 @@ uwsgi-bot-lax-adaptor:
 periodically-remove-expired-cache-entries:
     cron.present:
         - user: {{ pillar.elife.deploy_user.username }}
-        - name: cd /opt/bot-lax-adaptor/ && ./clear-expired-requests-cache.sh
+        # sqlite essentially duplicates the database for this operation
+        # - https://sqlite.org/tempfiles.html#write_ahead_log_wal_files
+        - name: SQLITE_TMPDIR=/ext/tmp cd /opt/bot-lax-adaptor/ && ./clear-expired-requests-cache.sh
         - identifier: rm-expired-cache-entries
         - minute: 0
         - hour: 0


### PR DESCRIPTION
fyi @NuclearRedeye 

`lax` has a helper that talks to the `elife-bot` project called `bot-lax-adaptor`. This project was intended to be a shim to keep all the article data wrangling logic out of `lax` and let Graham, a contractor and myself work on it quickly.

One of the article wrangling jobs is having to talk to Glencoe and IIIF to fetch media information to store in the article data payload sent to `lax`. This may be roughly 0 to 8 HTTP calls per-article.

A task we had to do often in the early days while the article spec was being hammered was a 'back fill', where the entire corpus of articles was transformed and sent to `lax`. This amounted to a DOS on IIIF (Glencoe didn't even blink) for essentially the same data we got the day prior.

The `requests-cache` library was introduced so the back fill happens more quickly and doesn't DOS anyone. Unfortunately, SQLite just grows and grows and you have to periodically run a VACUUM task to shrink the db. The temporary file used as the write-ahead log during this operation lives in `/tmp` by default unless you tell it otherwise with `TMPDIR` or `SQLITE_TMPDIR`.