### PR TITLE
nginx, requests with invalid/unsupported hosts are now dropped.

### DIFF
--- a/salt/lax/config/etc-nginx-sitesavailable-lax.conf
+++ b/salt/lax/config/etc-nginx-sitesavailable-lax.conf
@@ -9,14 +9,20 @@ server {
     listen 80 default_server;
     listen 443 default_server;
     
-    # respond to pings, but otherwise ...
     location /ping {
         add_header Cache-Control "must-revalidate, no-cache, no-store, private";
         add_header Content-Type "text/plain; charset=UTF-8";
         return 200 "pong";
     }
 
-    # ... close the connection on those that don't specify a known 'Host' header.
+    # deprecated. remove once the LB is hitting /ping instead of /api/v2/ping
+    location /api/v2/ping {
+        add_header Cache-Control "must-revalidate, no-cache, no-store, private";
+        add_header Content-Type "text/plain; charset=UTF-8";
+        return 200 "pong";
+    }
+
+    # ... close connection on those that don't specify a known 'Host' header.
     # - http://nginx.org/en/docs/http/request_processing.html
     location / {
         return 444;

--- a/salt/lax/config/etc-nginx-sitesavailable-lax.conf
+++ b/salt/lax/config/etc-nginx-sitesavailable-lax.conf
@@ -1,24 +1,27 @@
 # the upstream component nginx needs to connect to
 upstream django {
-    {% if salt['grains.get']('osrelease') == "14.04" %}
-    server unix:///tmp/lax-uwsgi.sock;
-    {% else %}
     # socket is now managed by systemd
     server unix:///var/run/uwsgi/lax.socket;
-    {% endif %}
 }
 
-# if an ELB is present, we need to respond to health checks
-{% if not salt['elife.cfg']('project.elb') %}
-# close connection on those that don't specify a 'host' header
-# http://nginx.org/en/docs/http/request_processing.html
+# default server, respond to /ping only
 server {
-    listen 80;
-    listen 443;
-    server_name "";
-    return 444;
+    listen 80 default_server;
+    listen 443 default_server;
+    
+    # respond to pings, but otherwise ...
+    location /ping {
+        add_header Cache-Control "must-revalidate, no-cache, no-store, private";
+        add_header Content-Type "text/plain; charset=UTF-8";
+        return 200 "pong";
+    }
+
+    # ... close the connection on those that don't specify a known 'Host' header.
+    # - http://nginx.org/en/docs/http/request_processing.html
+    location / {
+        return 444;
+    }
 }
-{% endif %}
 
 {% from 'elife/nginx-macros.sls' import consumer_groups_filter %}
 {{ consumer_groups_filter(pillar.lax.app.users) }}


### PR DESCRIPTION
except when responding to /ping requests. this is for the load balancer that doesn't specify a host header.