### PR TITLE
ubr, use an rds snapshot for lax instances using rds.

### DIFF
--- a/salt/lax/config/etc-ubr-lax-backup.yaml
+++ b/salt/lax/config/etc-ubr-lax-backup.yaml
@@ -1,2 +1,7 @@
+{% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
+rds-snapshot:
+    - {{ salt['elife.cfg']('project.rds_dbname') }}
+{% else %}
 postgresql-database:
     - {{ salt['elife.cfg']('project.rds_dbname') or pillar.elife.db.app.name }}
+{% endif %}


### PR DESCRIPTION
otherwise, default to postgresql database