### PR TITLE
Configure default IIIF environments for lax formula

### DIFF
--- a/salt/lax/config/opt-bot-lax-adaptor-app.cfg
+++ b/salt/lax/config/opt-bot-lax-adaptor-app.cfg
@@ -21,7 +21,7 @@ cdn_iiif: {{ scheme }}://iiif.elifesciences.org/lax:
 {%- else -%}
 cdn_iiif: {{ scheme }}://{{ pillar.elife.env }}--cdn-iiif.elifesciences.org/lax:
 {%- endif %}
-iiif: {{ scheme }}://{{ pillar.elife.env }}--iiif.elifesciences.org/lax:
+iiif: {{ scheme }}://iiif.{{ pillar.elife.env }}.elifesciences.org/lax:
 
 [glencoe]
 cache_requests: {{ pillar.lax.glencoe.cache_requests }}


### PR DESCRIPTION
https://github.com/elifesciences/issues/issues/9340

I would like to decommission *--iiif.elifesciences.org soon to make good on cost savings / modernisation goals. I've updated the configuration to use the equivalent paths (though depending on the env, some of these do not exist)